### PR TITLE
support local netlabels

### DIFF
--- a/kbplacer/key_placer.py
+++ b/kbplacer/key_placer.py
@@ -66,8 +66,8 @@ ANNOTATION_GUIDE_URL = (
 
 
 class KeyMatrix:
-    SUPPORTED_ROW_NAMES = ["ROW{}", "R{}"]
-    SUPPORTED_COLUMN_NAMES = ["COLUMN{}", "COL{}", "C{}"]
+    SUPPORTED_ROW_NAMES = ["ROW{}", "R{}", "/ROW{}", "/R{}"]
+    SUPPORTED_COLUMN_NAMES = ["COLUMN{}", "COL{}", "C{}", "/COLUMN{}", "/COL{}", "/C{}"]
 
     def __init__(self, board: pcbnew.BOARD, key_format: str, diode_format: str) -> None:
         self.key_format = key_format


### PR DESCRIPTION
VIA matrix coordinates only work when using the big red global labels eg. local networks like in this screenshot fail with 'Could not find switches connected to ('0', '0') matrix position which is used in provided layout.' 
this PR allows it to work with local netlabels 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2a8924d9-e48c-4def-b0f0-c8e2666cc058" />
