### PR TITLE
fix: use Rotate instead of SetOrientationDegrees

### DIFF
--- a/kbplacer/board_modifier.py
+++ b/kbplacer/board_modifier.py
@@ -126,7 +126,10 @@ def get_side(footprint: pcbnew.FOOTPRINT) -> Side:
 
 
 def set_rotation(footprint: pcbnew.FOOTPRINT, angle: float) -> None:
-    footprint.SetOrientationDegrees(angle)
+    current = get_orientation(footprint)
+    diff = current - angle
+    if diff != 0:
+        rotate(footprint, footprint.GetPosition(), diff)
 
 
 def reset_rotation(footprint: pcbnew.FOOTPRINT) -> None:


### PR DESCRIPTION
## Summary
Fixes an issue where switch/diode orientation changes (like 90 or 180 degrees) from the plugin dialog are ignored or do not properly rotate the footprint geometry during placement and routing in KiCad 8.

## Problem
Closes #58

When `SetOrientationDegrees()` is called on a footprint in the python API, it merely changes the orientation property, but does not always propagate the transformation to its child items (pads, graphics, etc.) until the board state is forcibly committed or re-evaluated by the GUI. 
Because the pad coordinates were not being updated in memory during script execution, the auto-router step still perceived the unrotated pad coordinates and routed tracks accordingly.

## Solution
Instead of explicitly overwriting the property using `footprint.SetOrientationDegrees(angle)`, this patch computes the required angle delta (`current - target`) and calls the existing `rotate()` function. This utilizes the `item.Rotate()` method in the KiCad API, which inherently applies the 2D geometric transformation across all footprint pads and geometries immediately in memory, allowing auto-routing and final footprint placement to succeed as intended.

## Testing
- Verified `rotate()` applies proper `EDA_ANGLE` delta mathematically across KiCad 7/8 versions.

---
*This PR was created with AI assistance.*